### PR TITLE
Fixes some CI issues.

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -8,5 +8,3 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: fastai/workflows/nbdev-ci@master
-        with:
-          version: "3.8"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["setuptools>=64", "wheel"]
+build-backend = "setuptools.build_meta"

--- a/settings.ini
+++ b/settings.ini
@@ -27,7 +27,7 @@ keywords = Open Hyperspectral Imager
 language = English
 status = 4
 user = openhsi
-requirements = fastcore xarray==2022.3.0 pandas<2.0.0 numpy scipy matplotlib fastcore fastprogress  pillow pandas tqdm bokeh holoviews panel param Py6S pyserial netcdf4 streamz pyviz_comms hvplot psutil h5py
+requirements = fastcore xarray==2022.3.0 pandas<2.0.0 numpy<2.0.0 scipy matplotlib fastcore fastprogress  pillow pandas tqdm bokeh holoviews panel param Py6S pyserial netcdf4 streamz pyviz_comms hvplot psutil h5py
 allowed_metadata_keys = 
 allowed_cell_metadata_keys = 
 jupyter_hooks = True


### PR DESCRIPTION
Fixes some CI issues. Remove need to fix python at version 3.8
- restrict numpy version <2.0.0. Fixes an issue with required pandas version (for calibration pickle comptablisty) and newer numy
- add minimal pyproject.toml for pip >24 PEP517.