### PR TITLE
Add mock-SDK pytest layer for camera backends (design proposal 0001)

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -45,3 +45,7 @@ jobs:
           fi
       - name: Run tests
         run: nbdev_test
+      - name: Run pytest suite (mock-SDK camera tests)
+        run: |
+          pip install pytest
+          python -m pytest tests/ -q

--- a/.gitignore
+++ b/.gitignore
@@ -141,7 +141,6 @@ checklink/cookies.txt
 .gitconfig
 
 cals/
-tests/
 working/
 data/
 

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,5 @@
+[pytest]
+testpaths = tests
+addopts = -ra -m "not hardware"
+markers =
+    hardware: requires a physical camera connected (deselected by default)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,108 @@
+"""Shared fixtures: fake vendor SDK modules injected via sys.modules, and a
+settings-file factory.
+
+Every camera backend imports its vendor SDK lazily inside __init__, so a fake
+module registered in sys.modules before construction is indistinguishable
+from the real SDK. No openhsi code changes are needed.
+"""
+
+import json
+import sys
+
+import pytest
+
+from fakes import arena as arena_fake
+from fakes import mvs as mvs_fake
+from fakes import pyspin as pyspin_fake
+from fakes import xiapi as xiapi_fake
+
+
+@pytest.fixture
+def fake_mvs(monkeypatch):
+    """Default single-USB-device Hikrobot MVS SDK fake."""
+    mod = mvs_fake.build_fake_mvs()
+    monkeypatch.setitem(sys.modules, "MvCameraControl_class", mod)
+    return mod
+
+
+@pytest.fixture
+def fake_mvs_factory(monkeypatch):
+    """Build a customised MVS fake (device count, serials, formats, ...)."""
+    def _build(**kwargs):
+        mod = mvs_fake.build_fake_mvs(**kwargs)
+        monkeypatch.setitem(sys.modules, "MvCameraControl_class", mod)
+        return mod
+    return _build
+
+
+@pytest.fixture
+def fake_xiapi(monkeypatch):
+    ximea_pkg, xiapi_mod = xiapi_fake.build_fake_ximea()
+    monkeypatch.setitem(sys.modules, "ximea", ximea_pkg)
+    monkeypatch.setitem(sys.modules, "ximea.xiapi", xiapi_mod)
+    return xiapi_mod
+
+
+@pytest.fixture
+def fake_arena(monkeypatch):
+    arena_pkg, system_mod = arena_fake.build_fake_arena()
+    monkeypatch.setitem(sys.modules, "arena_api", arena_pkg)
+    monkeypatch.setitem(sys.modules, "arena_api.system", system_mod)
+    return arena_pkg
+
+
+@pytest.fixture
+def fake_arena_factory(monkeypatch):
+    def _build(**kwargs):
+        arena_pkg, system_mod = arena_fake.build_fake_arena(**kwargs)
+        monkeypatch.setitem(sys.modules, "arena_api", arena_pkg)
+        monkeypatch.setitem(sys.modules, "arena_api.system", system_mod)
+        return arena_pkg
+    return _build
+
+
+@pytest.fixture
+def fake_flir(monkeypatch):
+    mod = pyspin_fake.build_fake_flir()
+    monkeypatch.setitem(sys.modules, "simple_pyspin", mod)
+    return mod
+
+
+@pytest.fixture
+def fake_flir_factory(monkeypatch):
+    def _build(**kwargs):
+        mod = pyspin_fake.build_fake_flir(**kwargs)
+        monkeypatch.setitem(sys.modules, "simple_pyspin", mod)
+        return mod
+    return _build
+
+
+@pytest.fixture
+def write_settings(tmp_path):
+    """Write a camera settings JSON to a temp file; returns its path.
+
+    Defaults match the shape of the shipped cam_settings_*.json assets and
+    can be overridden per test (`write_settings(pixel_format="Mono8")`).
+    """
+    counter = {"n": 0}
+
+    def _write(**overrides):
+        base = dict(
+            camera_id="0",
+            row_slice=[0, -1],
+            resolution=[1024, 1280],
+            fwhm_nm=4,
+            exposure_ms=10,
+            luminance=30000,
+            binxy=[1, 1],
+            win_offset=[0, 0],
+            win_resolution=[0, 0],
+            pixel_format="Mono10",
+        )
+        base.update(overrides)
+        counter["n"] += 1
+        path = tmp_path / f"settings_{counter['n']}.json"
+        path.write_text(json.dumps(base))
+        return str(path)
+
+    return _write

--- a/tests/fakes/arena.py
+++ b/tests/fakes/arena.py
@@ -1,0 +1,174 @@
+"""Fake Lucid Vision Arena SDK (`arena_api`) mirroring the surface used by
+LucidCameraBase, including buffers for the Mono8/Mono12-packed/Mono16 decode
+branches of `get_img`."""
+
+import ctypes
+import types
+from collections import deque
+
+import numpy as np
+
+
+class DeviceNotFoundError(Exception):
+    """arena_api raises this from create_device when no camera is connected."""
+
+
+class _Node:
+    def __init__(self, value, vmax=None, vmin=None):
+        self._value = value
+        self.max = vmax
+        self.min = vmin
+
+    @property
+    def value(self):
+        return self._value
+
+    @value.setter
+    def value(self, v):
+        self._value = v
+
+
+class _NodeMap(dict):
+    def get_node(self, names):
+        return {name: self[name] for name in names}
+
+
+def pack_mono12(pixels: np.ndarray) -> bytes:
+    """Inverse of LucidCameraBase.get_img's 12-bit unpacking:
+    fst = (b0<<4)+(b1>>4);  snd = (b2<<4)+(b1&15)."""
+    flat = pixels.astype(np.uint16).ravel()
+    assert len(flat) % 2 == 0, "12-bit packing needs an even pixel count"
+    out = bytearray()
+    for p0, p1 in zip(flat[0::2], flat[1::2]):
+        out.append((int(p0) >> 4) & 0xFF)
+        out.append(((int(p0) & 0xF) << 4) | (int(p1) & 0xF))
+        out.append((int(p1) >> 4) & 0xFF)
+    return bytes(out)
+
+
+class FakeArenaBuffer:
+    def __init__(self, array: np.ndarray, bits_per_pixel: int):
+        self.bits_per_pixel = bits_per_pixel
+        self.height, self.width = array.shape
+        if bits_per_pixel == 8:
+            payload = array.astype(np.uint8).tobytes()
+        elif bits_per_pixel in (10, 12):
+            payload = pack_mono12(array)
+        elif bits_per_pixel == 16:
+            payload = array.astype(np.uint16).tobytes()
+        else:
+            raise ValueError(f"unsupported bits_per_pixel {bits_per_pixel}")
+        self.buffer_size = len(payload)
+        self._backing = (ctypes.c_ubyte * len(payload)).from_buffer_copy(payload)
+        self.pdata = ctypes.cast(self._backing, ctypes.POINTER(ctypes.c_ubyte))
+
+
+class FakeArenaDevice:
+    def __init__(self, module):
+        self._mod = module
+        self.calls = []
+        self.streaming = False
+        self.frames = deque()
+        self.tl_stream_nodemap = _NodeMap({
+            "StreamAutoNegotiatePacketSize": _Node(False),
+            "StreamPacketResendEnable": _Node(False),
+        })
+        wmax, hmax = module.width_max, module.height_max
+        self.nodemap = _NodeMap({
+            "AcquisitionFrameRate": _Node(10.0, vmax=module.framerate_max, vmin=0.1),
+            "AcquisitionFrameRateEnable": _Node(False),
+            "AcquisitionMode": _Node("Continuous"),
+            "AcquisitionStart": _Node(None),
+            "AcquisitionStop": _Node(None),
+            "BinningHorizontal": _Node(1),
+            "BinningVertical": _Node(1),
+            "DevicePower": _Node(0),
+            "DeviceTemperature": _Node(module.temperature),
+            "DeviceUpTime": _Node(0),
+            "DeviceUserID": _Node("FakeLucid"),
+            "ExposureAuto": _Node("Continuous"),
+            "ExposureTime": _Node(10000.0, vmax=1e7, vmin=module.exposure_min_us),
+            "Gain": _Node(0.0),
+            "GammaEnable": _Node(True),
+            "Height": _Node(hmax, vmax=hmax, vmin=16),
+            "OffsetX": _Node(0, vmax=0, vmin=0),
+            "OffsetY": _Node(0, vmax=0, vmin=0),
+            "PixelFormat": _Node("Mono8"),
+            "ReverseX": _Node(False),
+            "ReverseY": _Node(False),
+            "Width": _Node(wmax, vmax=wmax, vmin=16),
+            "GevMACAddress": _Node(0x1C0FAF017BA0),
+            "DeviceSerialNumber": _Node(module.serial),
+        })
+
+    def queue_frame(self, array):
+        self.frames.append(np.asarray(array))
+
+    def start_stream(self, n):
+        self.calls.append(("start_stream", n))
+        self.streaming = True
+
+    def stop_stream(self):
+        self.calls.append(("stop_stream",))
+        self.streaming = False
+
+    def get_buffer(self):
+        self.calls.append(("get_buffer",))
+        bpp_by_format = {"Mono8": 8, "Mono10": 10, "Mono12": 12,
+                         "Mono12Packed": 12, "Mono10Packed": 10, "Mono16": 16}
+        bpp = bpp_by_format.get(self.nodemap["PixelFormat"].value, 12)
+        if self.frames:
+            frame = self.frames.popleft()
+        else:
+            frame = np.zeros((self.nodemap["Height"].value,
+                              self.nodemap["Width"].value), dtype=np.uint16)
+        return FakeArenaBuffer(frame, bpp)
+
+    def requeue_buffer(self, buf):
+        self.calls.append(("requeue_buffer",))
+
+
+class FakeArenaSystem:
+    def __init__(self, module):
+        self._mod = module
+        self.calls = []
+
+    @property
+    def device_infos(self):
+        if self._mod.n_devices == 0:
+            return []
+        return [{"serial": self._mod.serial}]
+
+    def destroy_device(self):
+        self.calls.append(("destroy_device",))
+
+    def create_device(self, device_infos=None):
+        self.calls.append(("create_device",))
+        if self._mod.n_devices == 0:
+            raise DeviceNotFoundError("No arena devices found")
+        dev = FakeArenaDevice(self._mod)
+        self._mod.devices.append(dev)
+        return [dev]
+
+
+def build_fake_arena(n_devices=1, serial="LUCID0001", width_max=1440,
+                     height_max=1080, temperature=30.0, framerate_max=100.0,
+                     exposure_min_us=20.0):
+    """Return (arena_api_pkg, system_module) impersonating
+    `from arena_api.system import system`."""
+    state = types.ModuleType("arena_api")
+    state.n_devices = n_devices
+    state.serial = serial
+    state.width_max, state.height_max = width_max, height_max
+    state.temperature = temperature
+    state.framerate_max = framerate_max
+    state.exposure_min_us = exposure_min_us
+    state.devices = []
+    state.DeviceNotFoundError = DeviceNotFoundError
+
+    system_mod = types.ModuleType("arena_api.system")
+    system_mod.system = FakeArenaSystem(state)
+
+    state.system = system_mod
+    state.last_device = lambda: state.devices[-1]
+    return state, system_mod

--- a/tests/fakes/mvs.py
+++ b/tests/fakes/mvs.py
@@ -1,0 +1,291 @@
+"""Fake Hikrobot MVS SDK (`MvCameraControl_class`) for testing without hardware.
+
+Mirrors exactly the call surface used by `openhsi.cameras.HikrobotCameraBase`.
+The fake records every SDK call so tests can assert call ordering, and exposes
+knobs for device count, serials, supported pixel formats, and queued frames.
+"""
+
+import ctypes
+import types
+from collections import deque
+
+import numpy as np
+
+# Real SDK constant values (backend only needs them to be self-consistent)
+MV_GIGE_DEVICE = 0x00000020
+MV_USB_DEVICE = 0x04000000
+MV_ACCESS_Exclusive = 1
+MV_TRIGGER_MODE_OFF = 0
+
+MV_OK = 0
+MV_E_HANDLE = 0x80000000
+MV_E_SUPPORT = 0x80000001
+MV_E_PARAMETER = 0x80000004
+MV_E_NODATA = 0x8000000A
+
+
+class _USB3V_INFO(ctypes.Structure):
+    _fields_ = [("chSerialNumber", ctypes.c_ubyte * 64)]
+
+
+class _GIGE_INFO(ctypes.Structure):
+    _fields_ = [("chSerialNumber", ctypes.c_ubyte * 16)]
+
+
+class _SPECIAL_INFO(ctypes.Union):
+    _fields_ = [("stUsb3VInfo", _USB3V_INFO), ("stGigEInfo", _GIGE_INFO)]
+
+
+class MV_CC_DEVICE_INFO(ctypes.Structure):
+    _fields_ = [("nTLayerType", ctypes.c_uint), ("SpecialInfo", _SPECIAL_INFO)]
+
+
+class MV_CC_DEVICE_INFO_LIST(ctypes.Structure):
+    _fields_ = [("nDeviceNum", ctypes.c_uint), ("pDeviceInfo", ctypes.c_void_p * 256)]
+
+
+class MVCC_INTVALUE(ctypes.Structure):
+    _fields_ = [("nCurValue", ctypes.c_uint), ("nMax", ctypes.c_uint),
+                ("nMin", ctypes.c_uint), ("nInc", ctypes.c_uint)]
+
+
+class MVCC_FLOATVALUE(ctypes.Structure):
+    _fields_ = [("fCurValue", ctypes.c_float), ("fMax", ctypes.c_float),
+                ("fMin", ctypes.c_float)]
+
+
+class MV_FRAME_OUT_INFO_EX(ctypes.Structure):
+    _fields_ = [("nWidth", ctypes.c_uint), ("nHeight", ctypes.c_uint),
+                ("enPixelType", ctypes.c_uint), ("nFrameNum", ctypes.c_uint),
+                ("nFrameLen", ctypes.c_uint)]
+
+
+def _bytes_per_pixel(pixel_format):
+    return 1 if "Mono8" in pixel_format else 2
+
+
+class _FakeHikCamera:
+    """One fake camera handle. Node state mimics a MV-CA013-21UM-shaped device."""
+
+    def __init__(self, module):
+        self._mod = module
+        self.calls = []
+        self.opened = False
+        self.grabbing = False
+        self.device_info = None
+        self.frames = deque()
+        # node state
+        self.ints = {
+            "Width":  {"cur": module.width_max, "max": module.width_max, "min": 16, "inc": 4},
+            "Height": {"cur": module.height_max, "max": module.height_max, "min": 16, "inc": 2},
+            "OffsetX": {"cur": 0, "max": 0, "min": 0, "inc": 4},
+            "OffsetY": {"cur": 0, "max": 0, "min": 0, "inc": 2},
+        }
+        self.floats = {
+            "ExposureTime": module.exposure_us_default,  # microseconds
+            "Gain": 0.0,
+        }
+        if module.has_temperature_node:
+            self.floats["DeviceTemperature"] = module.temperature
+        self.enums_by_string = {"PixelFormat": module.pixel_format_default,
+                                "ExposureAuto": "Continuous", "GainAuto": "Continuous"}
+        self.enums_by_value = {"TriggerMode": 1}
+
+    # -- helpers ----------------------------------------------------------
+    def _record(self, *call):
+        self.calls.append(call)
+
+    def _refresh_offset_limits(self):
+        self.ints["OffsetX"]["max"] = self._mod.width_max - self.ints["Width"]["cur"]
+        self.ints["OffsetY"]["max"] = self._mod.height_max - self.ints["Height"]["cur"]
+
+    def queue_frame(self, array):
+        """Queue a numpy array to be returned by the next frame grab."""
+        self.frames.append(("array", np.ascontiguousarray(array)))
+
+    def queue_raw(self, payload: bytes, width: int, height: int):
+        """Queue raw bytes with an explicit reported width/height (e.g. packed data)."""
+        self.frames.append(("raw", (payload, width, height)))
+
+    # -- static SDK entry points ------------------------------------------
+    @staticmethod
+    def MV_CC_Initialize():
+        return MV_OK
+
+    # -- handle lifecycle ---------------------------------------------------
+    def MV_CC_CreateHandle(self, dev_info):
+        self._record("MV_CC_CreateHandle",)
+        self.device_info = dev_info
+        return MV_OK
+
+    def MV_CC_OpenDevice(self, access_mode, switchover_key):
+        self._record("MV_CC_OpenDevice", access_mode)
+        self.opened = True
+        return MV_OK
+
+    def MV_CC_CloseDevice(self):
+        self._record("MV_CC_CloseDevice",)
+        self.opened = False
+        return MV_OK
+
+    def MV_CC_DestroyHandle(self):
+        self._record("MV_CC_DestroyHandle",)
+        return MV_OK
+
+    # -- nodes --------------------------------------------------------------
+    def MV_CC_SetEnumValue(self, name, value):
+        self._record("MV_CC_SetEnumValue", name, value)
+        if name.startswith("Binning") and not self._mod.supports_binning:
+            return MV_E_SUPPORT
+        self.enums_by_value[name] = value
+        return MV_OK
+
+    def MV_CC_SetEnumValueByString(self, name, value):
+        self._record("MV_CC_SetEnumValueByString", name, value)
+        if name == "PixelFormat" and value not in self._mod.supported_pixel_formats:
+            return MV_E_PARAMETER
+        self.enums_by_string[name] = value
+        return MV_OK
+
+    def MV_CC_SetIntValue(self, name, value):
+        self._record("MV_CC_SetIntValue", name, value)
+        node = self.ints.get(name)
+        if node is None:
+            return MV_E_SUPPORT
+        if not (node["min"] <= value <= node["max"]):
+            return MV_E_PARAMETER
+        node["cur"] = value
+        if name in ("Width", "Height"):
+            self._refresh_offset_limits()
+        return MV_OK
+
+    def MV_CC_GetIntValue(self, name, val):
+        self._record("MV_CC_GetIntValue", name)
+        if name == "PayloadSize":
+            bpp = _bytes_per_pixel(self.enums_by_string["PixelFormat"])
+            cur = self.ints["Width"]["cur"] * self.ints["Height"]["cur"] * bpp
+            val.nCurValue, val.nMax, val.nMin, val.nInc = cur, cur, 0, 1
+            return MV_OK
+        node = self.ints.get(name)
+        if node is None:
+            return MV_E_SUPPORT
+        val.nCurValue, val.nMax, val.nMin, val.nInc = (
+            node["cur"], node["max"], node["min"], node["inc"])
+        return MV_OK
+
+    def MV_CC_SetFloatValue(self, name, value):
+        self._record("MV_CC_SetFloatValue", name, value)
+        if name == "ExposureTime":
+            # real cameras round exposure to their internal clock; emulate that
+            self.floats[name] = float(round(value))
+            return MV_OK
+        if name in self.floats or name == "Gain":
+            self.floats[name] = float(value)
+            return MV_OK
+        return MV_E_SUPPORT
+
+    def MV_CC_GetFloatValue(self, name, val):
+        self._record("MV_CC_GetFloatValue", name)
+        if name not in self.floats:
+            return MV_E_SUPPORT
+        val.fCurValue = self.floats[name]
+        return MV_OK
+
+    # -- acquisition ----------------------------------------------------------
+    def MV_CC_StartGrabbing(self):
+        self._record("MV_CC_StartGrabbing",)
+        self.grabbing = True
+        return MV_OK
+
+    def MV_CC_StopGrabbing(self):
+        self._record("MV_CC_StopGrabbing",)
+        self.grabbing = False
+        return MV_OK
+
+    def MV_CC_GetOneFrameTimeout(self, pdata, size, frame_info, timeout_ms):
+        self._record("MV_CC_GetOneFrameTimeout", size, timeout_ms)
+        width = self.ints["Width"]["cur"]
+        height = self.ints["Height"]["cur"]
+        if self.frames:
+            kind, item = self.frames.popleft()
+            if kind == "array":
+                payload = item.tobytes()
+                height, width = item.shape
+            else:
+                payload, width, height = item
+        else:
+            bpp = _bytes_per_pixel(self.enums_by_string["PixelFormat"])
+            payload = bytes(width * height * bpp)
+        if len(payload) > size:
+            return MV_E_PARAMETER
+        ctypes.memmove(pdata, payload, len(payload))
+        frame_info.nWidth, frame_info.nHeight = width, height
+        frame_info.nFrameLen = len(payload)
+        return MV_OK
+
+
+def build_fake_mvs(serials=("DA1234567",), tlayer_types=None, width_max=1280,
+                   height_max=1024,
+                   supported_pixel_formats=("Mono8", "Mono10", "Mono12"),
+                   pixel_format_default="Mono8", supports_binning=False,
+                   temperature=42.5, has_temperature_node=True,
+                   exposure_us_default=10000.0, with_initialize=True):
+    """Build a module object impersonating `MvCameraControl_class`."""
+    mod = types.ModuleType("MvCameraControl_class")
+    mod.__dict__.update(
+        MV_GIGE_DEVICE=MV_GIGE_DEVICE, MV_USB_DEVICE=MV_USB_DEVICE,
+        MV_ACCESS_Exclusive=MV_ACCESS_Exclusive,
+        MV_TRIGGER_MODE_OFF=MV_TRIGGER_MODE_OFF,
+        MV_CC_DEVICE_INFO=MV_CC_DEVICE_INFO,
+        MV_CC_DEVICE_INFO_LIST=MV_CC_DEVICE_INFO_LIST,
+        MVCC_INTVALUE=MVCC_INTVALUE, MVCC_FLOATVALUE=MVCC_FLOATVALUE,
+        MV_FRAME_OUT_INFO_EX=MV_FRAME_OUT_INFO_EX,
+    )
+    mod.width_max, mod.height_max = width_max, height_max
+    mod.supported_pixel_formats = tuple(supported_pixel_formats)
+    mod.pixel_format_default = pixel_format_default
+    mod.supports_binning = supports_binning
+    mod.temperature = temperature
+    mod.has_temperature_node = has_temperature_node
+    mod.exposure_us_default = exposure_us_default
+    mod.cameras = []           # every _FakeHikCamera constructed
+    mod.initialize_calls = 0
+
+    # Build the device table (kept alive on the module: ctypes pointers don't own)
+    if tlayer_types is None:
+        tlayer_types = [MV_USB_DEVICE] * len(serials)
+    mod._device_structs = []
+    for serial, tlayer in zip(serials, tlayer_types):
+        info = MV_CC_DEVICE_INFO()
+        info.nTLayerType = tlayer
+        field = (info.SpecialInfo.stUsb3VInfo.chSerialNumber
+                 if tlayer == MV_USB_DEVICE
+                 else info.SpecialInfo.stGigEInfo.chSerialNumber)
+        raw = serial.encode()
+        field[:len(raw)] = raw
+        mod._device_structs.append(info)
+
+    class MvCamera:
+        def __new__(cls, *args, **kwargs):
+            cam = _FakeHikCamera(mod)
+            mod.cameras.append(cam)
+            return cam
+
+        @staticmethod
+        def MV_CC_EnumDevices(tlayer_mask, dev_list):
+            matching = [d for d in mod._device_structs if d.nTLayerType & tlayer_mask]
+            dev_list.nDeviceNum = len(matching)
+            for i, dev in enumerate(matching):
+                dev_list.pDeviceInfo[i] = ctypes.cast(
+                    ctypes.pointer(dev), ctypes.c_void_p)
+            return MV_OK
+
+    if with_initialize:
+        def _initialize():
+            mod.initialize_calls += 1
+            return MV_OK
+        MvCamera.MV_CC_Initialize = staticmethod(_initialize)
+
+    mod.MvCamera = MvCamera
+    mod.last_camera = lambda: mod.cameras[-1]
+    return mod

--- a/tests/fakes/pyspin.py
+++ b/tests/fakes/pyspin.py
@@ -1,0 +1,121 @@
+"""Fake `simple_pyspin` (FLIR) mirroring the surface used by FlirCameraBase.
+
+Nodes are plain attributes (that is how simple_pyspin exposes GenICam nodes),
+so the fake keeps a node dict behind __getattr__/__setattr__. The node set is
+configurable per camera generation, because FlirCameraBase's whole job is
+handling the naming differences (e.g. AcquisitionFrameRateEnable vs
+...Enabled).
+"""
+
+import types
+from collections import deque
+
+import numpy as np
+
+# Node names by camera generation (the ones FlirCameraBase touches)
+BFS_NODES = {
+    "GainAuto": "Off", "Gain": 0.0,
+    "AcquisitionFrameRateEnable": False, "AcquisitionFrameRate": 30,
+    "ExposureAuto": "Off", "ExposureTime": 10000.0,
+    "GammaEnable": True,
+    "Width": None, "Height": None, "OffsetX": 0, "OffsetY": 0,
+    "DeviceTemperature": 25.0,
+    "ExposureMin": 20.0,
+}
+GS3_NODES = {
+    "GainAuto": "Off", "Gain": 0.0,
+    "AcquisitionFrameRateAuto": "Off",
+    "AcquisitionFrameRateEnabled": False, "AcquisitionFrameRate": 30,
+    "ExposureAuto": "Off", "ExposureTime": 10000.0,
+    "GammaEnabled": True,
+    "Width": None, "Height": None, "OffsetX": 0, "OffsetY": 0,
+    "DeviceTemperature": 25.0,
+    "ExposureMinAbsVal_Float": 19.0,
+}
+
+
+class FakeFlirCamera:
+    _internal = ("_nodes", "calls", "frames", "initialized", "running",
+                 "SensorWidth", "SensorHeight", "camera_node_types",
+                 "_init_delay")
+
+    def __init__(self, nodes, sensor_width, sensor_height, init_delay=0):
+        object.__setattr__(self, "_nodes", dict(nodes))
+        object.__setattr__(self, "calls", [])
+        object.__setattr__(self, "frames", deque())
+        object.__setattr__(self, "initialized", False)
+        object.__setattr__(self, "running", False)
+        object.__setattr__(self, "SensorWidth", sensor_width)
+        object.__setattr__(self, "SensorHeight", sensor_height)
+        object.__setattr__(self, "camera_node_types",
+                           {name: type(v).__name__ for name, v in nodes.items()})
+        object.__setattr__(self, "_init_delay", init_delay)
+        self._nodes.setdefault("Width", sensor_width)
+        self._nodes.setdefault("Height", sensor_height)
+
+    # attribute-style node access, as simple_pyspin does
+    def __getattr__(self, name):
+        nodes = object.__getattribute__(self, "_nodes")
+        if name in nodes:
+            return nodes[name]
+        raise AttributeError(name)
+
+    def __setattr__(self, name, value):
+        if name in self._internal:
+            object.__setattr__(self, name, value)
+            return
+        nodes = object.__getattribute__(self, "_nodes")
+        if name not in nodes:
+            raise AttributeError(f"camera has no node {name}")
+        nodes[name] = value
+        object.__getattribute__(self, "calls").append(("set", name, value))
+
+    # -- lifecycle -----------------------------------------------------------
+    def init(self):
+        self.calls.append(("init",))
+        if self._init_delay > 0:
+            # camera not immediately initialized; FlirCameraBase polls with sleep()
+            object.__setattr__(self, "_init_delay", self._init_delay - 1)
+        else:
+            object.__setattr__(self, "initialized", True)
+
+    def start(self):
+        self.calls.append(("start",))
+        object.__setattr__(self, "running", True)
+
+    def stop(self):
+        self.calls.append(("stop",))
+        object.__setattr__(self, "running", False)
+
+    def close(self):
+        self.calls.append(("close",))
+
+    # -- frames ---------------------------------------------------------------
+    def queue_frame(self, array):
+        self.frames.append(np.asarray(array))
+
+    def get_array(self):
+        self.calls.append(("get_array",))
+        if self.frames:
+            return self.frames.popleft()
+        return np.zeros((self._nodes["Height"], self._nodes["Width"]),
+                        dtype=np.uint16)
+
+
+def build_fake_flir(style="BFS", sensor_width=1440, sensor_height=1080,
+                    init_delay=0):
+    """Return a module impersonating `simple_pyspin` with the given node style."""
+    mod = types.ModuleType("simple_pyspin")
+    nodes = BFS_NODES if style == "BFS" else GS3_NODES
+    mod.cameras = []
+
+    class Camera:
+        def __new__(cls, *args, **kwargs):
+            cam = FakeFlirCamera(nodes, sensor_width, sensor_height,
+                                 init_delay=init_delay)
+            mod.cameras.append(cam)
+            return cam
+
+    mod.Camera = Camera
+    mod.last_camera = lambda: mod.cameras[-1]
+    return mod

--- a/tests/fakes/xiapi.py
+++ b/tests/fakes/xiapi.py
@@ -1,0 +1,134 @@
+"""Fake Ximea SDK (`ximea.xiapi`) mirroring the surface used by XimeaCameraBase."""
+
+import types
+from collections import deque
+
+import numpy as np
+
+
+class FakeXiImage:
+    def __init__(self):
+        self._array = None
+
+    def get_image_data_numpy(self):
+        return self._array
+
+
+class FakeXiCamera:
+    def __init__(self, module):
+        self._mod = module
+        self.calls = []
+        self.opened_by = None
+        self.acquiring = False
+        self.frames = deque()
+        self.height = module.height_max
+        self.width = module.width_max
+        self.offset_x = 0
+        self.offset_y = 0
+        self.exposure_us = 10000.0
+        self.gain = 0.0
+        self.imgdataformat = "XI_MONO8"
+        self.binning_vertical = 1
+
+    def _record(self, *call):
+        self.calls.append(call)
+
+    def queue_frame(self, array):
+        self.frames.append(np.ascontiguousarray(array))
+
+    # -- device lifecycle --------------------------------------------------
+    def open_device(self):
+        self._record("open_device",)
+        self.opened_by = "first"
+
+    def open_device_by_SN(self, serial):
+        self._record("open_device_by_SN", serial)
+        if serial != self._mod.serial:
+            raise RuntimeError(f"Xi_error: no device with serial {serial}")
+        self.opened_by = serial
+
+    def close_device(self):
+        self._record("close_device",)
+
+    def get_device_sn(self):
+        return self._mod.serial
+
+    # -- configuration -------------------------------------------------------
+    def enable_horizontal_flip(self):
+        self._record("enable_horizontal_flip",)
+
+    def set_binning_vertical(self, v):
+        self._record("set_binning_vertical", v)
+        self.binning_vertical = v
+
+    def set_binning_vertical_mode(self, mode):
+        self._record("set_binning_vertical_mode", mode)
+
+    def set_height(self, v): self._record("set_height", v); self.height = v
+    def set_width(self, v): self._record("set_width", v); self.width = v
+    def get_height(self): return self.height
+    def get_width(self): return self.width
+    def get_height_maximum(self): return self._mod.height_max
+    def get_width_maximum(self): return self._mod.width_max
+
+    def set_offsetY(self, v): self._record("set_offsetY", v); self.offset_y = v
+    def set_offsetX(self, v): self._record("set_offsetX", v); self.offset_x = v
+    def get_offsetY_maximum(self): return self._mod.height_max - self.height
+    def get_offsetX_maximum(self): return self._mod.width_max - self.width
+
+    def set_exposure_direct(self, us):
+        self._record("set_exposure_direct", us)
+        # emulate hardware rounding to a coarser clock
+        self.exposure_us = float(int(us // 10) * 10)
+
+    def get_exposure(self):
+        return self.exposure_us
+
+    def set_gain_direct(self, g): self._record("set_gain_direct", g); self.gain = g
+
+    def set_imgdataformat(self, fmt):
+        self._record("set_imgdataformat", fmt)
+        self.imgdataformat = fmt
+
+    def set_output_bit_depth(self, depth): self._record("set_output_bit_depth", depth)
+    def enable_output_bit_packing(self): self._record("enable_output_bit_packing",)
+    def disable_aeag(self): self._record("disable_aeag",)
+
+    # -- acquisition -----------------------------------------------------------
+    def start_acquisition(self): self._record("start_acquisition",); self.acquiring = True
+    def stop_acquisition(self): self._record("stop_acquisition",); self.acquiring = False
+
+    def get_image(self, img):
+        self._record("get_image",)
+        if self.frames:
+            img._array = self.frames.popleft()
+        else:
+            dtype = np.uint16 if "16" in self.imgdataformat else np.uint8
+            img._array = np.zeros((self.height, self.width), dtype=dtype)
+
+    def get_temp(self):
+        return self._mod.temperature
+
+
+def build_fake_ximea(serial="XIMEA0001", width_max=800, height_max=644,
+                     temperature=35.0):
+    """Return (ximea_package, xiapi_module) impersonating `from ximea import xiapi`."""
+    xiapi_mod = types.ModuleType("ximea.xiapi")
+    xiapi_mod.serial = serial
+    xiapi_mod.width_max, xiapi_mod.height_max = width_max, height_max
+    xiapi_mod.temperature = temperature
+    xiapi_mod.cameras = []
+
+    class Camera:
+        def __new__(cls, *args, **kwargs):
+            cam = FakeXiCamera(xiapi_mod)
+            xiapi_mod.cameras.append(cam)
+            return cam
+
+    xiapi_mod.Camera = Camera
+    xiapi_mod.Image = FakeXiImage
+    xiapi_mod.last_camera = lambda: xiapi_mod.cameras[-1]
+
+    ximea_pkg = types.ModuleType("ximea")
+    ximea_pkg.xiapi = xiapi_mod
+    return ximea_pkg, xiapi_mod

--- a/tests/test_flir.py
+++ b/tests/test_flir.py
@@ -1,0 +1,101 @@
+"""Mock-SDK tests for the FLIR backend (FlirCameraBase/FlirCamera) and its
+attribute-compatibility helpers."""
+
+import numpy as np
+import pytest
+
+from openhsi.cameras import FlirCamera, get_min_exposure, set_camera_attribute
+
+from fakes.pyspin import BFS_NODES, GS3_NODES, FakeFlirCamera
+
+FLIR_SETTINGS = dict(resolution=[1080, 1440], win_resolution=[0, 0],
+                     win_offset=[0, 0], pixel_format="Mono16", exposure_ms=10)
+
+
+def make_cam(write_settings, n_lines=3, settings=None, **cam_kwargs):
+    merged = {**FLIR_SETTINGS, **(settings or {})}
+    json_path = write_settings(**merged)
+    return FlirCamera(json_path=json_path, n_lines=n_lines,
+                      warn_mem_use=False, **cam_kwargs)
+
+
+# --- helper-function unit tests (no camera class involved) -------------------
+
+def test_set_attribute_primary_name():
+    cam = FakeFlirCamera(GS3_NODES, 1440, 1080)
+    assert set_camera_attribute(cam, "AcquisitionFrameRateEnabled", True)
+    assert cam.AcquisitionFrameRateEnabled is True
+
+
+def test_set_attribute_falls_back_to_alternative():
+    cam = FakeFlirCamera(BFS_NODES, 1440, 1080)   # BFS has ...Enable, not ...Enabled
+    assert set_camera_attribute(cam, "AcquisitionFrameRateEnabled", True,
+                                alternatives=["AcquisitionFrameRateEnable"])
+    assert cam.AcquisitionFrameRateEnable is True
+
+
+def test_set_attribute_missing_not_required():
+    cam = FakeFlirCamera(BFS_NODES, 1440, 1080)
+    assert set_camera_attribute(cam, "AcquisitionFrameRateAuto", "Off",
+                                required=False) is False
+
+
+def test_set_attribute_missing_required_raises_with_hint():
+    cam = FakeFlirCamera(BFS_NODES, 1440, 1080)
+    with pytest.raises(AttributeError, match="AcquisitionFrameRateEnable"):
+        set_camera_attribute(cam, "AcquisitionFrameRateEnabled", True)
+
+
+@pytest.mark.parametrize("nodes,expected", [
+    (GS3_NODES, 19.0),    # ExposureMinAbsVal_Float
+    (BFS_NODES, 20.0),    # ExposureMin
+    ({"ExposureTime": 10.0}, 1.0),   # nothing found -> safe default
+])
+def test_get_min_exposure(nodes, expected):
+    cam = FakeFlirCamera(nodes, 1440, 1080)
+    assert get_min_exposure(cam) == pytest.approx(expected)
+
+
+# --- FlirCamera construction ---------------------------------------------------
+
+@pytest.mark.parametrize("style", ["BFS", "GS3"])
+def test_connects_and_configures(style, fake_flir_factory, write_settings):
+    mod = fake_flir_factory(style=style)
+    cam = make_cam(write_settings)
+    flir = mod.last_camera()
+    assert flir.initialized
+    assert flir.GainAuto == "Off" and flir.Gain == 0
+    assert flir.ExposureAuto == "Off"
+    assert flir.ExposureTime == pytest.approx(10_000.0)
+    # frame rate derived from exposure: int(min(1000/(10+1), 120)) == 90
+    assert flir.AcquisitionFrameRate == 90
+    # window falls back to the full sensor when win_resolution is (0, 0)
+    assert flir.Width == 1440 and flir.Height == 1080
+
+
+def test_get_img_returns_frame(fake_flir, write_settings):
+    cam = make_cam(write_settings)
+    frame = np.arange(12, dtype=np.uint16).reshape(3, 4)
+    fake_flir.last_camera().queue_frame(frame)
+    np.testing.assert_array_equal(cam.get_img(), frame)
+
+
+def test_set_exposure_clamps_to_device_minimum(fake_flir, write_settings):
+    cam = make_cam(write_settings)
+    cam.set_exposure(0.001)   # below the 20 us (0.02 ms) device minimum
+    assert cam.settings["exposure_ms"] == pytest.approx(0.02)
+    assert fake_flir.last_camera().ExposureTime == pytest.approx(20.0)
+    assert fake_flir.last_camera().AcquisitionFrameRate == 120  # hits the cap
+
+
+def test_get_temp(fake_flir, write_settings):
+    cam = make_cam(write_settings)
+    assert cam.get_temp() == pytest.approx(25.0)
+
+
+@pytest.mark.xfail(raises=NameError, strict=True,
+                   reason="known bug: cameras.py polls flircam.initialized "
+                          "with sleep(0.1) but never imports sleep")
+def test_slow_initialisation_polls(fake_flir_factory, write_settings):
+    fake_flir_factory(init_delay=1)   # camera not initialized on first check
+    make_cam(write_settings)

--- a/tests/test_hikrobot.py
+++ b/tests/test_hikrobot.py
@@ -1,0 +1,129 @@
+"""Mock-SDK tests for the Hikrobot backend (HikrobotCameraBase/HikrobotCamera)."""
+
+import math
+
+import numpy as np
+import pytest
+
+from openhsi.cameras import HikrobotCamera
+
+
+def make_cam(write_settings, n_lines=4, **cam_kwargs):
+    json_path = write_settings(**cam_kwargs.pop("settings", {}))
+    return HikrobotCamera(json_path=json_path, n_lines=n_lines,
+                          warn_mem_use=False, **cam_kwargs)
+
+
+def test_connects_and_configures(fake_mvs, write_settings):
+    cam = make_cam(write_settings)
+    hik = fake_mvs.last_camera()
+    assert hik.opened
+    assert fake_mvs.initialize_calls == 1
+    # free-run with manual exposure/gain, to match calibration data
+    assert hik.enums_by_value["TriggerMode"] == fake_mvs.MV_TRIGGER_MODE_OFF
+    assert hik.enums_by_string["ExposureAuto"] == "Off"
+    assert hik.enums_by_string["GainAuto"] == "Off"
+    assert hik.floats["Gain"] == 0.0
+    assert hik.enums_by_string["PixelFormat"] == "Mono10"
+    # full-frame window when win_resolution is (0, 0)
+    assert (cam.rows, cam.cols) == (1024, 1280)
+    assert hik.ints["Width"]["cur"] == 1280 and hik.ints["Height"]["cur"] == 1024
+
+
+def test_custom_window(fake_mvs, write_settings):
+    cam = make_cam(write_settings,
+                   settings=dict(win_resolution=[512, 640], win_offset=[8, 4]))
+    hik = fake_mvs.last_camera()
+    assert (cam.rows, cam.cols) == (512, 640)
+    assert hik.ints["Height"]["cur"] == 512 and hik.ints["Width"]["cur"] == 640
+    assert hik.ints["OffsetY"]["cur"] == 8 and hik.ints["OffsetX"]["cur"] == 4
+
+
+def test_serial_selection(fake_mvs_factory, write_settings):
+    mod = fake_mvs_factory(serials=("AAA111", "BBB222"))
+    make_cam(write_settings, serial_num="BBB222")
+    # the chosen device's serial is what the backend read back
+    hik = mod.last_camera()
+    raw = bytes(hik.device_info.SpecialInfo.stUsb3VInfo.chSerialNumber)
+    assert raw.split(b"\x00")[0].decode() == "BBB222"
+
+
+def test_serial_no_match_raises(fake_mvs, write_settings):
+    with pytest.raises(RuntimeError, match="serial number"):
+        make_cam(write_settings, serial_num="NOPE")
+
+
+def test_no_devices_raises(fake_mvs_factory, write_settings):
+    fake_mvs_factory(serials=())
+    with pytest.raises(RuntimeError, match="No Hikrobot camera found"):
+        make_cam(write_settings)
+
+
+def test_unsupported_pixel_format_raises(fake_mvs, write_settings):
+    with pytest.raises(RuntimeError, match="PixelFormat"):
+        make_cam(write_settings, settings=dict(pixel_format="Mono12Packed"))
+
+
+def test_get_img_mono8(fake_mvs, write_settings):
+    cam = make_cam(write_settings, settings=dict(pixel_format="Mono8"))
+    hik = fake_mvs.last_camera()
+    frame = np.arange(1024 * 1280, dtype=np.uint8).reshape(1024, 1280)
+    hik.queue_frame(frame)
+    img = cam.get_img()
+    assert img.dtype == np.uint8 and img.shape == (1024, 1280)
+    np.testing.assert_array_equal(img, frame)
+
+
+def test_get_img_mono12_roundtrip(fake_mvs, write_settings):
+    cam = make_cam(write_settings, settings=dict(pixel_format="Mono12"))
+    hik = fake_mvs.last_camera()
+    rng = np.random.default_rng(0)
+    frame = rng.integers(0, 4096, size=(1024, 1280), dtype=np.uint16)
+    hik.queue_frame(frame)
+    img = cam.get_img()
+    assert img.dtype == np.uint16
+    np.testing.assert_array_equal(img, frame)
+
+
+def test_get_img_rejects_packed_length(fake_mvs, write_settings):
+    """A frame whose byte count is neither H*W nor 2*H*W (e.g. packed 12-bit)
+    must raise, not return a garbled cube."""
+    cam = make_cam(write_settings)
+    hik = fake_mvs.last_camera()
+    w, h = 1280, 1024
+    hik.queue_raw(bytes(w * h * 3 // 2), w, h)
+    with pytest.raises(RuntimeError, match="unpacked pixel format"):
+        cam.get_img()
+
+
+def test_set_exposure_stores_actual(fake_mvs, write_settings):
+    cam = make_cam(write_settings)
+    cam.set_exposure(7.4999)   # fake rounds ExposureTime to whole microseconds
+    assert cam.settings["exposure_ms"] == pytest.approx(7.5, abs=1e-3)
+    assert fake_mvs.last_camera().floats["ExposureTime"] == pytest.approx(7500.0)
+
+
+def test_get_temp(fake_mvs, write_settings):
+    cam = make_cam(write_settings)
+    assert cam.get_temp() == pytest.approx(42.5)
+
+
+def test_get_temp_missing_node_is_nan(fake_mvs_factory, write_settings):
+    fake_mvs_factory(has_temperature_node=False)
+    cam = make_cam(write_settings)
+    assert math.isnan(cam.get_temp())
+
+
+def test_collect_fills_datacube(fake_mvs, write_settings):
+    n_lines = 4
+    with make_cam(write_settings, n_lines=n_lines) as cam:
+        cam.collect()
+        assert cam.dc.data.shape == (1024, n_lines, 1280)
+        assert cam.cam_temperatures.data[0] == pytest.approx(42.5)
+    hik = fake_mvs.last_camera()
+    # trigger mode was configured before acquisition started
+    names = [c[0] for c in hik.calls]
+    assert names.index("MV_CC_SetEnumValue") < names.index("MV_CC_StartGrabbing")
+    # context-manager exit released the camera
+    assert names[-2:] == ["MV_CC_CloseDevice", "MV_CC_DestroyHandle"]
+    assert not hik.grabbing and not hik.opened

--- a/tests/test_lucid.py
+++ b/tests/test_lucid.py
@@ -1,0 +1,99 @@
+"""Mock-SDK tests for the Lucid Vision backend (LucidCameraBase/LucidCamera)."""
+
+import numpy as np
+import pytest
+
+from openhsi.cameras import LucidCamera
+
+LUCID_SETTINGS = dict(resolution=[1080, 1440], win_resolution=[0, 0],
+                      win_offset=[0, 0], pixel_format="Mono12Packed",
+                      exposure_ms=10)
+
+
+def make_cam(write_settings, n_lines=3, settings=None, **cam_kwargs):
+    merged = {**LUCID_SETTINGS, **(settings or {})}
+    json_path = write_settings(**merged)
+    return LucidCamera(json_path=json_path, n_lines=n_lines,
+                       warn_mem_use=False, **cam_kwargs)
+
+
+def test_connects_and_configures(fake_arena, write_settings):
+    cam = make_cam(write_settings)
+    dev = fake_arena.last_device()
+    # stream tuning applied
+    assert dev.tl_stream_nodemap["StreamAutoNegotiatePacketSize"].value is True
+    assert dev.tl_stream_nodemap["StreamPacketResendEnable"].value is True
+    # manual exposure/gain to match calibration data
+    assert dev.nodemap["ExposureAuto"].value == "Off"
+    assert dev.nodemap["Gain"].value == 0.0
+    assert dev.nodemap["PixelFormat"].value == "Mono12Packed"
+    # full-frame window
+    assert (cam.rows, cam.cols) == (1080, 1440)
+    assert cam.settings["camera_id"] == "FakeLucid"
+
+
+def test_get_img_unpacks_mono12(fake_arena, write_settings):
+    """Craft a packed 12-bit buffer with known pixel values and check the
+    unpacking branch reconstructs them exactly."""
+    cam = make_cam(write_settings)
+    dev = fake_arena.last_device()
+    frame = np.array([[0x001, 0xFFF, 0xABC, 0x123],
+                      [0x800, 0x0F0, 0x555, 0xAAA]], dtype=np.uint16)
+    dev.queue_frame(frame)
+    img = cam.get_img()
+    assert img.shape == frame.shape
+    np.testing.assert_array_equal(img, frame)
+
+
+def test_get_img_mono8(fake_arena, write_settings):
+    cam = make_cam(write_settings, settings=dict(pixel_format="Mono8"))
+    dev = fake_arena.last_device()
+    frame = np.arange(16, dtype=np.uint8).reshape(4, 4)
+    dev.queue_frame(frame)
+    np.testing.assert_array_equal(cam.get_img(), frame)
+
+
+def test_get_img_mono16(fake_arena, write_settings):
+    cam = make_cam(write_settings, settings=dict(pixel_format="Mono16"))
+    dev = fake_arena.last_device()
+    frame = (np.arange(16, dtype=np.uint16) * 1000).reshape(4, 4)
+    dev.queue_frame(frame)
+    np.testing.assert_array_equal(cam.get_img(), frame)
+
+
+def test_set_exposure_enables_framerate_cap(fake_arena, write_settings):
+    cam = make_cam(write_settings)
+    dev = fake_arena.last_device()
+    # long exposure: nominal framerate 0.98e6/us below max -> cap engaged
+    cam.set_exposure(50)
+    assert dev.nodemap["AcquisitionFrameRateEnable"].value is True
+    assert dev.nodemap["AcquisitionFrameRate"].value == pytest.approx(19.6)
+    assert cam.settings["exposure_ms"] == pytest.approx(50)
+    # short exposure: nominal framerate above device max -> cap disabled
+    cam.set_exposure(5)
+    assert dev.nodemap["AcquisitionFrameRateEnable"].value is False
+    assert dev.nodemap["ExposureTime"].value == pytest.approx(5000.0)
+
+
+def test_set_exposure_clamps_to_minimum(fake_arena, write_settings):
+    cam = make_cam(write_settings)
+    cam.set_exposure(0.001)   # below the 20 us device minimum
+    assert cam.settings["exposure_ms"] == pytest.approx(0.02)
+
+
+@pytest.mark.xfail(raises=NameError, strict=True,
+                   reason="known bug: cameras.py catches DeviceNotFoundError "
+                          "without importing it, so the handler itself raises "
+                          "NameError instead of the intended RuntimeError")
+def test_no_device_raises_friendly_error(fake_arena_factory, write_settings):
+    fake_arena_factory(n_devices=0)
+    with pytest.raises(RuntimeError, match="connect a lucid vision camera"):
+        make_cam(write_settings)
+
+
+@pytest.mark.xfail(raises=NameError, strict=True,
+                   reason="known bug: get_mac references undefined global "
+                          "'cam' instead of self")
+def test_get_mac(fake_arena, write_settings):
+    cam = make_cam(write_settings)
+    assert cam.get_mac() == "1c:0f:af:01:7b:a0"

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -1,0 +1,123 @@
+"""Processing-pipeline recipe tests: no vendor SDKs, uses the shipped example
+settings/calibration from nbs/assets/."""
+
+import copy
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from openhsi.cameras import SimulatedCamera
+from openhsi.data import CameraProperties
+
+ASSETS = Path(__file__).parent.parent / "nbs" / "assets"
+JSON_PATH = str(ASSETS / "cam_settings.json")
+CAL_PATH = str(ASSETS / "cam_calibration.nc")
+
+# lvl -> expected transform-method names (from CameraProperties.set_processing_lvl)
+RECIPES = {
+    -1: [],
+    0: ["crop"],
+    1: ["crop", "fast_smile"],
+    2: ["crop", "fast_smile", "fast_bin"],
+    3: ["crop", "fast_smile", "slow_bin"],
+    4: ["crop", "fast_smile", "fast_bin", "dn2rad"],
+    5: ["crop", "fast_smile", "dn2rad", "fast_bin"],
+    6: ["crop", "fast_smile", "fast_bin", "dn2rad", "rad2ref_6SV"],
+    7: ["crop", "fast_smile", "dn2rad", "slow_bin"],
+    8: ["crop", "fast_smile", "dn2rad", "slow_bin", "rad2ref_6SV"],
+}
+# calibration keys each level's tfm_setup needs beyond the basics
+NEEDS = {4: {"rad_ref", "sfit"}, 5: {"rad_ref", "sfit"},
+         6: {"rad_ref", "sfit", "rad_fit"}, 7: {"rad_ref", "sfit"},
+         8: {"rad_ref", "sfit", "rad_fit"}}
+
+
+@pytest.fixture(scope="module")
+def _props_template():
+    # Load the calibration NetCDF exactly once per module:
+    # load_calibration_data_from_netcdf leaves the xarray dataset open, and
+    # repeatedly re-opening the same file segfaults HDF5 eventually.
+    return CameraProperties(json_path=JSON_PATH, cal_path=CAL_PATH)
+
+
+@pytest.fixture
+def props(_props_template):
+    # Fresh object per test (deepcopy) because set_processing_lvl leaks state
+    # between calls (see test_reconfiguring_processing_level_is_stateless).
+    return copy.deepcopy(_props_template)
+
+
+def _skip_if_unsupported(props, lvl):
+    missing = NEEDS.get(lvl, set()) - set(props.calibration.keys())
+    if missing:
+        pytest.skip(f"shipped calibration lacks {sorted(missing)} for lvl {lvl}")
+
+
+@pytest.mark.parametrize("lvl", sorted(RECIPES))
+def test_recipe_composition(props, lvl):
+    _skip_if_unsupported(props, lvl)
+    props.set_processing_lvl(lvl)
+    assert [t.__name__ for t in props.tfm_list] == RECIPES[lvl]
+
+
+@pytest.mark.parametrize("lvl", [2, 3, 4, 5, 7])
+def test_binned_and_radiance_levels_are_float32(props, lvl):
+    _skip_if_unsupported(props, lvl)
+    props.set_processing_lvl(lvl)
+    assert props.dtype_out == np.float32
+
+
+def test_lvl0_crops_to_row_slice(props):
+    props.set_processing_lvl(0)
+    out = props.pipeline(props.calibration["flat_field_pic"])
+    assert out.shape[0] == np.ptp(props.settings["row_slice"])
+    assert out.shape == props.dc_shape[:1] + props.dc_shape[1:]
+
+
+def test_binning_reduces_spectral_axis(props):
+    props.set_processing_lvl(1)
+    unbinned = props.pipeline(props.calibration["flat_field_pic"]).shape
+    props.set_processing_lvl(2)
+    binned = props.pipeline(props.calibration["flat_field_pic"]).shape
+    assert binned[1] < unbinned[1]
+
+
+@pytest.mark.parametrize("pixel_format,expected", [
+    ("Mono8", np.uint8), ("Mono10", np.uint16), ("Mono12", np.uint16),
+    ("Mono16", np.uint16), ("XI_RAW16", np.uint16), ("Mono12Packed", np.uint16),
+])
+def test_dtype_in_from_pixel_format(write_settings, pixel_format, expected):
+    props = CameraProperties(json_path=write_settings(pixel_format=pixel_format))
+    props.set_processing_lvl(-1)
+    assert props.dtype_in == expected
+
+
+def test_custom_tfms_override_presets(props):
+    marker = lambda x: x
+    props.set_processing_lvl(2, custom_tfms=[marker])
+    assert props.tfm_list == [marker]
+
+
+@pytest.mark.xfail(raises=ValueError, strict=True,
+                   reason="known bug: set_processing_lvl(4) sets "
+                          "need_rad_after_fast_bin and never clears it, so a "
+                          "later set_processing_lvl(5) on the same object bins "
+                          "the dn2rad reference data twice and the pipeline "
+                          "raises a broadcast ValueError (proposal 0004)")
+def test_reconfiguring_processing_level_is_stateless(props):
+    _skip_if_unsupported(props, 5)
+    props.set_processing_lvl(4)
+    props.set_processing_lvl(5)
+    out = props.pipeline(props.calibration["flat_field_pic"])
+    assert out.shape == props.dc_shape
+
+
+def test_simulated_camera_end_to_end(tmp_path):
+    """Integration smoke test: the hardware-free camera collects a full cube."""
+    with SimulatedCamera(img_path=str(ASSETS / "rocky_beach.png"), n_lines=8,
+                         processing_lvl=2, warn_mem_use=False,
+                         json_path=JSON_PATH, cal_path=CAL_PATH) as cam:
+        cam.collect()
+        assert cam.dc.data.shape[1] == 8
+        assert cam.dc.data.dtype == np.float32

--- a/tests/test_settings_flow.py
+++ b/tests/test_settings_flow.py
@@ -1,0 +1,55 @@
+"""How constructor kwargs flow into `settings` — the documented contract and
+the known deviations.
+
+Two different override semantics exist in the class chain today:
+- CameraProperties only overrides keys already present in the settings file;
+- OpenHSI.__init__ then does settings.update(kwargs) wholesale.
+These tests pin down the current behaviour so refactors (design proposal
+0004) change it deliberately, not accidentally.
+"""
+
+import pytest
+
+from openhsi.cameras import HikrobotCamera, XimeaCamera
+from openhsi.data import CameraProperties
+
+
+def test_kwarg_overrides_existing_settings_key(write_settings):
+    props = CameraProperties(json_path=write_settings(exposure_ms=10),
+                             exposure_ms=5)
+    assert props.settings["exposure_ms"] == 5
+
+
+def test_unknown_kwarg_is_not_added_to_settings(write_settings):
+    props = CameraProperties(json_path=write_settings(), not_a_real_key=1)
+    assert "not_a_real_key" not in props.settings
+
+
+def test_openhsi_stores_all_kwargs_in_settings(fake_mvs, write_settings):
+    """OpenHSI.__init__ copies every remaining kwarg into settings wholesale
+    (documented current behaviour, not necessarily desirable)."""
+    cam = HikrobotCamera(json_path=write_settings(), n_lines=4,
+                         warn_mem_use=False)
+    assert cam.settings["n_lines"] == 4
+
+
+def test_hikrobot_exposure_kwarg_reaches_hardware(fake_mvs, write_settings):
+    """Hikrobot deliberately does NOT capture exposure_ms in its signature, so
+    the kwarg flows through to the settings override and the device."""
+    cam = HikrobotCamera(json_path=write_settings(exposure_ms=10),
+                         exposure_ms=5, n_lines=4, warn_mem_use=False)
+    assert cam.settings["exposure_ms"] == pytest.approx(5.0)
+    assert fake_mvs.last_camera().floats["ExposureTime"] == pytest.approx(5000.0)
+
+
+@pytest.mark.xfail(strict=True,
+                   reason="known bug: XimeaCameraBase.__init__ captures "
+                          "exposure_ms in its signature, so the kwarg never "
+                          "reaches the CameraProperties settings override and "
+                          "is silently ignored (design proposal 0004)")
+def test_ximea_exposure_kwarg_reaches_hardware(fake_xiapi, write_settings):
+    cam = XimeaCamera(json_path=write_settings(exposure_ms=10,
+                                               resolution=[644, 800],
+                                               pixel_format="XI_RAW16"),
+                      exposure_ms=5, n_lines=4, warn_mem_use=False)
+    assert cam.settings["exposure_ms"] == pytest.approx(5.0)

--- a/tests/test_ximea.py
+++ b/tests/test_ximea.py
@@ -1,0 +1,57 @@
+"""Mock-SDK tests for the Ximea backend (XimeaCameraBase/XimeaCamera)."""
+
+import numpy as np
+import pytest
+
+from openhsi.cameras import XimeaCamera
+
+XIMEA_SETTINGS = dict(resolution=[644, 800], win_resolution=[0, 0],
+                      win_offset=[0, 0], pixel_format="XI_RAW16", exposure_ms=2)
+
+
+def make_cam(fake, write_settings, n_lines=4, settings=None, **cam_kwargs):
+    merged = {**XIMEA_SETTINGS, **(settings or {})}
+    json_path = write_settings(**merged)
+    return XimeaCamera(json_path=json_path, n_lines=n_lines,
+                       warn_mem_use=False, **cam_kwargs)
+
+
+def test_connects_and_configures(fake_xiapi, write_settings):
+    cam = make_cam(fake_xiapi, write_settings)
+    xicam = fake_xiapi.last_camera()
+    assert xicam.opened_by == "first"       # open_device() when no serial given
+    called = [c[0] for c in xicam.calls]
+    assert "enable_horizontal_flip" in called
+    assert "disable_aeag" in called
+    # XI_RAW16 implies 12-bit output depth with bit packing
+    assert ("set_output_bit_depth", "XI_BPP_12") in xicam.calls
+    assert ("enable_output_bit_packing",) in xicam.calls
+    # full-frame window
+    assert (cam.rows, cam.cols) == (644, 800)
+
+
+def test_open_by_serial(fake_xiapi, write_settings):
+    make_cam(fake_xiapi, write_settings, serial_num="XIMEA0001")
+    assert fake_xiapi.last_camera().opened_by == "XIMEA0001"
+
+
+def test_get_img_returns_frame(fake_xiapi, write_settings):
+    cam = make_cam(fake_xiapi, write_settings)
+    frame = np.arange(644 * 800, dtype=np.uint16).reshape(644, 800)
+    fake_xiapi.last_camera().queue_frame(frame)
+    np.testing.assert_array_equal(cam.get_img(), frame)
+
+
+def test_set_exposure_stores_rounded_actual(fake_xiapi, write_settings):
+    cam = make_cam(fake_xiapi, write_settings)
+    cam.set_exposure(1.234)   # fake rounds to 10 us -> 1230 us
+    assert cam.settings["exposure_ms"] == pytest.approx(1.23)
+
+
+def test_collect_fills_datacube(fake_xiapi, write_settings):
+    n_lines = 3
+    with make_cam(fake_xiapi, write_settings, n_lines=n_lines) as cam:
+        cam.collect()
+        assert cam.dc.data.shape == (644, n_lines, 800)
+    xicam = fake_xiapi.last_camera()
+    assert not xicam.acquiring


### PR DESCRIPTION
## Summary

Implements design proposal 0001 (`design-docs` branch): a plain pytest suite with **fake vendor SDK modules**, giving the hardware-flagged camera logic its first CI coverage. No library code changes — every backend already imports its SDK lazily inside `__init__`, so a fake module registered in `sys.modules` is indistinguishable from the real SDK.

**Result: 65 passed, 5 xfailed, ~5 s, no vendor SDKs installed.**

### What's covered

- `tests/fakes/` — scriptable fakes for the four SDKs: Hikrobot MVS (`MvCameraControl_class`, with real ctypes structures so the `ctypes.cast` device-enumeration path is exercised authentically), Ximea `xiapi`, Lucid `arena_api` (including a bit-exact Mono12-packed encoder), FLIR `simple_pyspin` (per-generation node sets: BFS vs GS3 naming).
- Device enumeration and serial-number selection, including no-device and no-match error paths.
- Window/offset arithmetic and full-frame fallbacks.
- `get_img` pixel-format branches: Mono8, 2-byte Mono10/12/16 round-trips, Lucid 12-bit unpacking verified against crafted packed buffers, and rejection of unexpected frame lengths.
- Exposure rounding/clamping and frame-rate-cap logic per backend.
- Settings kwarg flow (`tests/test_settings_flow.py`) — pins down the two different override semantics in the class chain.
- Processing-level recipes -1..8, dtype mapping, custom transforms, and a `SimulatedCamera` end-to-end collect (`tests/test_pipeline.py`).
- CI: pytest step added to `test.yaml` after `nbdev_test`. A `hardware` pytest marker is registered (deselected by default) for future on-camera tests.
- Removes a stale `tests/` entry in `.gitignore` that would have silently ignored the suite.

### Known bugs documented as strict xfails (fixes deliberately out of scope — proposal 0004)

1. `XimeaCamera(exposure_ms=…)` is silently ignored — the base-class signature captures the kwarg before the settings override sees it.
2. `cameras.py` uses `sleep()` without importing it — FLIR slow-initialisation polling raises `NameError`.
3. `cameras.py` catches `DeviceNotFoundError` without importing it — Lucid's friendly no-camera message is unreachable (`NameError` instead).
4. `LucidCameraBase.get_mac` references an undefined global `cam`.
5. `set_processing_lvl` never clears `need_rad_after_fast_bin`, so reconfiguring a live object (e.g. level 4 → 5, the `ProcessRawDatacube` re-processing path) double-bins the radiance reference and raises a broadcast `ValueError`. **Found by this suite.**

Each xfail is `strict=True`: when a fix lands, the test flips loudly and becomes the regression guard.

### Additional finding (not yet encoded as a test)

6. `load_calibration_data_from_netcdf` never closes its xarray dataset, so repeated `CameraProperties` construction leaks HDF5 handles — this segfaulted the test process until worked around with a load-once fixture. Fix belongs with proposals 0002/0004.

## Testing

- `python -m pytest tests/ -q` → 65 passed, 5 xfailed; stable across repeated runs.
- `nbdev_export`/`nbdev_clean` untouched (this PR adds no notebook or generated-module changes).
- Branch rebased onto master after #62 merged.

https://claude.ai/code/session_01X7rBuamcTJVbaEYdifbJrA